### PR TITLE
Add debug logging for QR match payload in non-production

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ CORS_ALLOWED_ORIGIN="https://your-qr-app.com"
 In non-production environments (development and preview), the QR code generation endpoint logs the full QR match payload to the server console. This helps with debugging and understanding the data structure being encoded in QR codes.
 
 **When it logs:**
-- Development environment (`NODE_ENV !== "production"`)
-- Vercel preview deployments (`VERCEL_ENV !== "production"`)
+- Local development (`npm run dev` - `VERCEL_ENV` is undefined)
+- Vercel preview deployments (`VERCEL_ENV === "preview"`)
 
 **Example log output:**
 ```

--- a/src/app/api/qr-match/generate/route.ts
+++ b/src/app/api/qr-match/generate/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
   );
 
   // Log QR payload in non-production environments for debugging
-  if (process.env.VERCEL_ENV !== "production" && process.env.NODE_ENV !== "production") {
+  if (process.env.VERCEL_ENV !== "production") {
     console.log("[QR Debug] Generated QR match payload:", JSON.stringify(qrMatchData, null, 2));
   }
 


### PR DESCRIPTION
- Log full QR match data to console when generating QR codes
- Only enabled in development and preview environments
- Production environment remains silent to avoid log clutter
- Documented the debug logging feature in README