### PR TITLE
Fix tournament edit form placeholder text

### DIFF
--- a/src/components/Results/Title.tsx
+++ b/src/components/Results/Title.tsx
@@ -76,6 +76,7 @@ function EditButton() {
     setShowModal(false);
   };
   const openModal = () => {
+    setInput(context.tournament?.name || "");
     setShowModal(true);
   };
 
@@ -96,9 +97,9 @@ function EditButton() {
             id="name"
             name="name"
             type="text"
+            value={input}
             onChange={(e) => setInput(e.target.value)}
             required
-            placeholder={context.tournament.name}
             className="flex w-full justify-center rounded-md border-0 py-1.5 px-3 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-500 focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6"
           />
           <div className="flex items-center justify-center gap-2 text-sm font-semibold">


### PR DESCRIPTION
When editing a tournament name, the old name is now pre-filled as the input value instead of just being shown as a placeholder. This allows users to easily modify the existing name without having to retype it entirely.

Changes:
- Initialize input state with tournament name when modal opens
- Change input field to use value prop instead of placeholder