### PR TITLE
Step 4: link matches to rounds via round_id

### DIFF
--- a/src/app/api/qr-match/generate/route.test.ts
+++ b/src/app/api/qr-match/generate/route.test.ts
@@ -154,6 +154,7 @@ describe('POST /api/qr-match/generate - Admin Authorization', () => {
       player2: 'Player Two',
       round: 1,
       match: 1,
+      round_id: null,
     });
   });
 

--- a/src/app/api/qr-match/generate/route.ts
+++ b/src/app/api/qr-match/generate/route.ts
@@ -10,6 +10,7 @@ interface GenerateQRRequest {
   tournamentId: number;
   round: number;
   match: number;
+  round_id?: number | null;
 }
 
 export async function POST(request: Request) {
@@ -35,7 +36,7 @@ export async function POST(request: Request) {
     });
   }
 
-  const { player1, player2, tournamentId, round, match } = data.value;
+  const { player1, player2, tournamentId, round, match, round_id = null } = data.value;
 
   // Fetch tournament settings to check if submitter identity is required
   const tournament = await db
@@ -84,6 +85,7 @@ export async function POST(request: Request) {
     player2,
     round,
     match,
+    round_id,
   });
 
   if (!storeResult.success) {

--- a/src/app/api/qr-match/submit/route.ts
+++ b/src/app/api/qr-match/submit/route.ts
@@ -111,7 +111,7 @@ export async function POST(request: Request) {
     tournament_id: matchData.tournament_id,
     round: matchData.round,
     match: matchData.match,
-    round_id: matchData.round_id,
+    round_id: matchData.round_id ?? null,
     player1_hits,
     player2_hits,
     winner,

--- a/src/app/api/qr-match/submit/route.ts
+++ b/src/app/api/qr-match/submit/route.ts
@@ -111,6 +111,7 @@ export async function POST(request: Request) {
     tournament_id: matchData.tournament_id,
     round: matchData.round,
     match: matchData.match,
+    round_id: matchData.round_id,
     player1_hits,
     player2_hits,
     winner,

--- a/src/components/BulkMatchEntry.test.tsx
+++ b/src/components/BulkMatchEntry.test.tsx
@@ -57,6 +57,8 @@ const mockTournamentContext = {
   setHidden: vi.fn(),
   pools: [] as { id: number; name: string; tournament_id: number }[],
   setPools: vi.fn(),
+  rounds: [] as { id: number; tournament_id: number; round_order: number; type: string }[],
+  setRounds: vi.fn(),
 };
 
 vi.mock('@/context/TournamentContext', () => ({

--- a/src/components/BulkMatchEntry.tsx
+++ b/src/components/BulkMatchEntry.tsx
@@ -525,6 +525,9 @@ export default function BulkMatchEntry({ closeModal }: BulkMatchEntryProps) {
         winner: match.winner,
         tournament_id: context.tournament!.id,
         round: context.activeRound,
+        round_id:
+          context.rounds.find((r) => r.round_order === context.activeRound)
+            ?.id ?? null,
       };
 
       try {

--- a/src/components/QRMatchModal.tsx
+++ b/src/components/QRMatchModal.tsx
@@ -53,6 +53,9 @@ export default function QRMatchModal({ closeModal, player1, player2 }: QRMatchMo
           tournamentId: context.tournament.id,
           round: context.activeRound,
           match: 1, // Default match number, could be calculated
+          round_id:
+            context.rounds.find((r) => r.round_order === context.activeRound)
+              ?.id ?? null,
         }),
       });
 

--- a/src/components/Results/Brackets/Tournament.test.tsx
+++ b/src/components/Results/Brackets/Tournament.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import Tournament from "./Tournament";
+import type { Player } from "@/types/Player";
+
+// ── Mock dependencies ───────────────────────────────────────────────────────
+
+vi.mock("@/database/getTournament", () => ({
+  getTournamentsForSeeding: vi
+    .fn()
+    .mockResolvedValue({ success: true, value: [] }),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUserContext: () => ({ user: null, setUser: vi.fn() }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ locale: "en", id: "1" }),
+}));
+
+vi.mock("@/components/Results/Title", () => ({
+  TournamentTitle: () => <span>Test Tournament</span>,
+}));
+
+// RoundNav just displays navigation — not under test here
+vi.mock("@/components/rounds", () => ({
+  default: () => null,
+}));
+
+// Prevent Modal/AddMatch from rendering and pulling in more context deps
+vi.mock("@/components/modal", () => ({
+  default: ({
+    children,
+    isOpen,
+  }: {
+    children: React.ReactNode;
+    isOpen: boolean;
+  }) => (isOpen ? <div>{children}</div> : null),
+}));
+
+vi.mock("@/components/newmatch", () => ({
+  default: () => null,
+}));
+
+const mockUseTournamentContext = vi.fn();
+vi.mock("@/context/TournamentContext", () => ({
+  useTournamentContext: () => mockUseTournamentContext(),
+}));
+
+// ── Translation messages ────────────────────────────────────────────────────
+
+const messages = {
+  Brackets: {
+    selectseed: "Select a tournament to seed from",
+    noRRtournamentsfound: "No tournaments found",
+  },
+  NewMatch: {
+    match: "Match",
+    title: "Round",
+    player1: "Player 1",
+    player2: "Player 2",
+    points: "Points",
+    submit: "Submit",
+    back: "Back",
+    selectbothplayers: "Select both players",
+    duplicateplayers: "Duplicate players",
+    selectwinnerfordraw: "Select winner for draw",
+    notournamentfound: "No tournament found",
+    addmatchfailed: "Add match failed",
+    matchexists1: "Match between",
+    matchexists2: "already exists for round",
+    unexpectederror: "Unexpected error",
+    noplayers: "No players",
+    tournament: "Tournament",
+    generating: "Generating...",
+    generateQR: "Generate QR",
+    generateNew: "Generate new",
+    done: "Done",
+  },
+};
+
+// ── Test data ───────────────────────────────────────────────────────────────
+
+const baseMatchFields = {
+  tournament_id: 1,
+  submitted_by_token: null,
+  submitted_at: null,
+};
+
+/**
+ * Round played in elimination round 1 (rounds-table id 10, round_order 2).
+ * Alice wins 5-3.
+ */
+const elim1Match = {
+  ...baseMatchFields,
+  id: 1,
+  player1: "Alice",
+  player2: "Bob",
+  player1_hits: 5,
+  player2_hits: 3,
+  winner: "Alice",
+  round: 1, // bracket stage depth (final)
+  match: 1,
+  round_id: 10,
+};
+
+/**
+ * Round played in elimination round 2 (rounds-table id 11, round_order 3).
+ * Bob wins 2-7.
+ */
+const elim2Match = {
+  ...baseMatchFields,
+  id: 2,
+  player1: "Alice",
+  player2: "Bob",
+  player1_hits: 2,
+  player2_hits: 7,
+  winner: "Bob",
+  round: 1, // bracket stage depth (final)
+  match: 1,
+  round_id: 11,
+};
+
+const alice: Player = {
+  player: {
+    player_name: "Alice",
+    tournament_id: 1,
+    bracket_match: null,
+    bracket_seed: null,
+    pool_id: null,
+  },
+  matches: [elim1Match, elim2Match],
+};
+
+const bob: Player = {
+  player: {
+    player_name: "Bob",
+    tournament_id: 1,
+    bracket_match: null,
+    bracket_seed: null,
+    pool_id: null,
+  },
+  matches: [elim1Match, elim2Match],
+};
+
+const twoEliminationRounds = [
+  { id: 10, tournament_id: 1, round_order: 2, type: "elimination" },
+  { id: 11, tournament_id: 1, round_order: 3, type: "elimination" },
+];
+
+const baseTournamentContext = {
+  tournament: {
+    id: 1,
+    name: "Test Tournament",
+    format: "Brackets",
+    date: new Date(),
+  },
+  setTournament: vi.fn(),
+  players: [alice, bob] as (Player | null)[],
+  setPlayers: vi.fn(),
+  pools: [],
+  setPools: vi.fn(),
+  loading: false,
+  setLoading: vi.fn(),
+  setActiveRound: vi.fn(),
+  hidden: false,
+  setHidden: vi.fn(),
+  rounds: twoEliminationRounds,
+  setRounds: vi.fn(),
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("Brackets/Tournament — multi-elimination round switching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Alice as winner when first elimination round (round_id=10) is active", () => {
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2, // maps to rounds-table row with id=10
+    });
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    // Alice wins in elim1Match → Bob is the loser and gets line-through
+    expect(screen.getByText("Bob").className).toContain("line-through");
+    expect(screen.getByText("Alice").className).not.toContain("line-through");
+  });
+
+  it("shows Bob as winner when second elimination round (round_id=11) is active", () => {
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 3, // maps to rounds-table row with id=11
+    });
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    // Bob wins in elim2Match → Alice is the loser and gets line-through
+    expect(screen.getByText("Alice").className).toContain("line-through");
+    expect(screen.getByText("Bob").className).not.toContain("line-through");
+  });
+
+  it("does not filter matches for a single elimination round (legacy fallback)", () => {
+    // With only one elimination round, round_id filtering is skipped so legacy
+    // tournaments (round_id = null) continue to work.
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 1,
+      rounds: [{ id: 10, tournament_id: 1, round_order: 1, type: "elimination" }],
+    });
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    // Both players appear in the bracket without errors
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
+  it("renders an empty bracket when there are no players", () => {
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2,
+      players: [],
+    });
+
+    const { container } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    // No player cells should appear
+    expect(screen.queryByText("Alice")).toBeNull();
+    expect(screen.queryByText("Bob")).toBeNull();
+  });
+});

--- a/src/components/Results/Brackets/Tournament.test.tsx
+++ b/src/components/Results/Brackets/Tournament.test.tsx
@@ -232,6 +232,35 @@ describe("Brackets/Tournament — multi-elimination round switching", () => {
     expect(screen.getByText("Bob")).toBeTruthy();
   });
 
+  it("falls back to all matches when no matches have the active round_id (legacy data with multiple elimination rounds)", () => {
+    // Matches exist but all have round_id = null (migrated before Step 4).
+    // The bracket should not go blank.
+    const legacyAlice: Player = {
+      player: { ...alice.player },
+      matches: [{ ...elim1Match, round_id: null }],
+    };
+    const legacyBob: Player = {
+      player: { ...bob.player },
+      matches: [{ ...elim1Match, round_id: null }],
+    };
+
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2, // round_id=10, but no matches carry it
+      players: [legacyAlice, legacyBob],
+    });
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    // Both players should still appear (fallback to unfiltered)
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
   it("renders an empty bracket when there are no players", () => {
     mockUseTournamentContext.mockReturnValue({
       ...baseTournamentContext,
@@ -239,7 +268,7 @@ describe("Brackets/Tournament — multi-elimination round switching", () => {
       players: [],
     });
 
-    const { container } = render(
+    render(
       <NextIntlClientProvider locale="en" messages={messages}>
         <Tournament />
       </NextIntlClientProvider>,

--- a/src/components/Results/Brackets/Tournament.tsx
+++ b/src/components/Results/Brackets/Tournament.tsx
@@ -288,7 +288,30 @@ export default function Tournament() {
     if (context.loading) return [];
     if (!context.tournament) return [];
 
-    let players: (Player | null)[] = context.players;
+    // Find the active round's DB id to scope match lookup.
+    const activeRoundId = context.rounds.find(
+      (r) => r.round_order === context.activeRound,
+    )?.id;
+
+    // When multiple elimination rounds exist, filter each player's matches to
+    // only those belonging to the currently active round so that switching tabs
+    // shows a different bracket. For a single elimination round (or legacy data
+    // where round_id is null) we skip filtering to preserve the original behaviour.
+    const eliminationRoundCount = context.rounds.filter(
+      (r) => r.type === "elimination",
+    ).length;
+
+    let players: (Player | null)[] =
+      activeRoundId && eliminationRoundCount > 1
+        ? context.players.map((p) =>
+            p
+              ? {
+                  ...p,
+                  matches: p.matches.filter((m) => m.round_id === activeRoundId),
+                }
+              : null,
+          )
+        : context.players;
 
     if (!players.some((player) => player === null)) {
       const seeded = players.some((player) => player?.player.bracket_seed);
@@ -343,6 +366,8 @@ export default function Tournament() {
     context.tournament,
     capacity,
     context.loading,
+    context.activeRound,
+    context.rounds,
   ]);
 
   useEffect(() => {

--- a/src/components/Results/Brackets/Tournament.tsx
+++ b/src/components/Results/Brackets/Tournament.tsx
@@ -303,14 +303,25 @@ export default function Tournament() {
 
     let players: (Player | null)[] =
       activeRoundId && eliminationRoundCount > 1
-        ? context.players.map((p) =>
-            p
-              ? {
-                  ...p,
-                  matches: p.matches.filter((m) => m.round_id === activeRoundId),
-                }
-              : null,
-          )
+        ? (() => {
+            const filtered = context.players.map((p) =>
+              p
+                ? {
+                    ...p,
+                    matches: p.matches.filter(
+                      (m) => m.round_id === activeRoundId,
+                    ),
+                  }
+                : null,
+            );
+            // Only use the filtered list when at least one player actually has
+            // matches for this round. If every player's list is empty (e.g.,
+            // legacy data where round_id was never populated) fall back to the
+            // unfiltered set so the bracket doesn't render blank.
+            return filtered.some((p) => p && p.matches.length > 0)
+              ? filtered
+              : context.players;
+          })()
         : context.players;
 
     if (!players.some((player) => player === null)) {

--- a/src/components/Results/RoundRobin/Player.tsx
+++ b/src/components/Results/RoundRobin/Player.tsx
@@ -22,7 +22,7 @@ type Hits = {
 };
 
 interface Opponents {
-  [key: string]: { winner: string | null; hits: number }[];
+  [key: string]: Record<number, { winner: string | null; hits: number }>;
 }
 
 export function Player({
@@ -121,7 +121,7 @@ export function Player({
 
         if (opponentName) {
           if (!newOpponents[opponentName]) {
-            newOpponents[opponentName] = [];
+            newOpponents[opponentName] = {};
           }
           // Index by round_id when available so match lookup works correctly
           // across mixed-type rounds; fall back to round number for legacy
@@ -177,7 +177,14 @@ export function Player({
         {++nthRow}
       </td>
 
-      {opponentList.map((opponent, index) => {
+      {(() => {
+        // Compute once outside the per-opponent loop to avoid an O(n) find on
+        // every cell render (which would be O(players²) overall).
+        const activeRoundId = context.rounds.find(
+          (r) => r.round_order === context.activeRound,
+        )?.id;
+
+        return opponentList.map((opponent, index) => {
         if (!opponent) return;
         const key = player.player.player_name + index;
         // Used to set dark bg color if players match, can't play versus self
@@ -187,9 +194,6 @@ export function Player({
         const matches = matchesByOpponent[opponent.player.player_name];
         // Prefer round_id-keyed entry (new matches); fall back to numeric
         // round_order for legacy matches without round_id.
-        const activeRoundId = context.rounds.find(
-          (r) => r.round_order === context.activeRound,
-        )?.id;
         const matchData =
           matches &&
           ((activeRoundId ? matches[activeRoundId] : undefined) ??
@@ -244,7 +248,8 @@ export function Player({
             {result}
           </td>
         );
-      })}
+        });
+      })()}
 
       {/* calculate win percentage based on matches associated with player */}
       <td

--- a/src/components/Results/RoundRobin/Player.tsx
+++ b/src/components/Results/RoundRobin/Player.tsx
@@ -123,7 +123,11 @@ export function Player({
           if (!newOpponents[opponentName]) {
             newOpponents[opponentName] = [];
           }
-          newOpponents[opponentName][match.round] = {
+          // Index by round_id when available so match lookup works correctly
+          // across mixed-type rounds; fall back to round number for legacy
+          // matches that pre-date the rounds table.
+          const roundKey = match.round_id ?? match.round;
+          newOpponents[opponentName][roundKey] = {
             winner: match.winner,
             hits: playerHits,
           };
@@ -181,7 +185,15 @@ export function Player({
           opponent.player.player_name === player.player.player_name;
 
         const matches = matchesByOpponent[opponent.player.player_name];
-        const matchData = matches && matches[context.activeRound];
+        // Prefer round_id-keyed entry (new matches); fall back to numeric
+        // round_order for legacy matches without round_id.
+        const activeRoundId = context.rounds.find(
+          (r) => r.round_order === context.activeRound,
+        )?.id;
+        const matchData =
+          matches &&
+          ((activeRoundId ? matches[activeRoundId] : undefined) ??
+            matches[context.activeRound]);
 
         // Early return if no match data found between players
         if (!matchData) {

--- a/src/components/newmatch.test.tsx
+++ b/src/components/newmatch.test.tsx
@@ -43,6 +43,8 @@ const mockTournamentContext = {
   setPlayers: mockSetPlayers,
   activeRound: 1,
   setActiveRound: vi.fn(),
+  rounds: [] as { id: number; tournament_id: number; round_order: number; type: string }[],
+  setRounds: vi.fn(),
 };
 
 vi.mock('@/context/TournamentContext', () => ({

--- a/src/components/newmatch.tsx
+++ b/src/components/newmatch.tsx
@@ -77,6 +77,9 @@ const AddMatch = ({
       winner: formData.get("winner") as string | null,
       tournament_id: Number(context.tournament.id),
       round: bracketMatch?.round ?? context.activeRound,
+      round_id:
+        context.rounds.find((r) => r.round_order === context.activeRound)?.id ??
+        null,
     };
 
     if (!form.player1.trim() || !form.player2.trim()) {

--- a/src/components/newmatch.tsx
+++ b/src/components/newmatch.tsx
@@ -68,6 +68,14 @@ const AddMatch = ({
       return;
     }
 
+    // round_id always comes from context.activeRound (the rounds-table row for the
+    // current tab). For bracket matches, bracketMatch.round is the bracket stage
+    // depth (1 = final, 2 = semi, …), which is a different concept — using it for
+    // the rounds-table lookup would return the wrong row.
+    const round_id =
+      context.rounds.find((r) => r.round_order === context.activeRound)?.id ??
+      null;
+
     const form: MatchForm = {
       match: bracketMatch?.match ?? 1,
       player1: formData.get("player1") as string,
@@ -77,9 +85,7 @@ const AddMatch = ({
       winner: formData.get("winner") as string | null,
       tournament_id: Number(context.tournament.id),
       round: bracketMatch?.round ?? context.activeRound,
-      round_id:
-        context.rounds.find((r) => r.round_order === context.activeRound)?.id ??
-        null,
+      round_id,
     };
 
     if (!form.player1.trim() || !form.player2.trim()) {

--- a/src/database/addQRMatch.ts
+++ b/src/database/addQRMatch.ts
@@ -9,7 +9,9 @@ interface QRMatchPending {
   player2: string;
   round: number;
   match: number;
-  round_id: number | null;
+  // Optional so that QR codes generated before round_id was introduced
+  // (or mocked in tests without it) still deserialise correctly.
+  round_id?: number | null;
   created_at: Date;
 }
 

--- a/src/database/addQRMatch.ts
+++ b/src/database/addQRMatch.ts
@@ -9,6 +9,7 @@ interface QRMatchPending {
   player2: string;
   round: number;
   match: number;
+  round_id: number | null;
   created_at: Date;
 }
 

--- a/src/types/MatchTypes.ts
+++ b/src/types/MatchTypes.ts
@@ -24,6 +24,7 @@ export type MatchForm = {
   tournament_id: number;
   round: number;
   match: number;
+  round_id?: number | null; // FK to rounds table; null for legacy matches without round tracking
 };
 
 export type MatchFormSubmit = Omit<MatchForm, "winner"> & { winner: string }; // winner is required on submission


### PR DESCRIPTION
## Summary

- Populate `matches.round_id` on all match-creation paths: Add Match, Bulk Match Entry, and QR Match flow
- Update `RoundRobin/Player.tsx` to index match lookup by `round_id` (with numeric `round` fallback for legacy data)
- Fix elimination round switching: `Brackets/Tournament.tsx` now scopes each player's match list to the active `round_id` when multiple elimination rounds exist; falls back to unfiltered when all matches have `round_id = null` (legacy data)
- Add `Brackets/Tournament.test.tsx` with 5 tests covering round switching, legacy fallback, and empty-player cases
- Make `QRMatchPending.round_id` optional so pre-Step-4 QR codes and test fixtures remain valid; normalize to `null` on submission

## Changed files

| File | Change |
|---|---|
| `src/components/newmatch.tsx` | Send `round_id` with new match; clarify derivation vs bracket stage depth |
| `src/components/BulkMatchEntry.tsx` | Send `round_id` with bulk matches |
| `src/components/QRMatchModal.tsx` | Include `round_id` in QR generate request |
| `src/app/api/qr-match/generate/route.ts` | Accept and store `round_id` |
| `src/database/addQRMatch.ts` | Add optional `round_id` to `QRMatchPending`; normalize to `null` on read |
| `src/app/api/qr-match/submit/route.ts` | Forward `round_id` (normalized) to match upsert |
| `src/components/Results/RoundRobin/Player.tsx` | Index opponents by `round_id ?? round`; use `Record` not sparse array; hoist `activeRoundId` out of render loop |
| `src/components/Results/Brackets/Tournament.tsx` | Filter player matches by active `round_id` when multiple elimination rounds exist; legacy fallback when no round-scoped matches found |
| `src/components/Results/Brackets/Tournament.test.tsx` | New — 5 tests for round switching and legacy fallback |
| `src/components/newmatch.test.tsx` | Add `rounds` to mock context |
| `src/components/BulkMatchEntry.test.tsx` | Add `rounds` to mock context |
| `src/app/api/qr-match/generate/route.test.ts` | Assert `round_id: null` in `addQRMatch` call |

## Test plan

- [x] All 289 tests pass (`npm run test`)
- [x] Add Match form sends `round_id` for the active round
- [x] Bulk Match Entry sends `round_id`
- [x] QR Match generate includes `round_id`; submit normalizes missing `round_id` to `null`
- [x] Pool round-robin table shows correct match per round (round_id-keyed, no sparse arrays)
- [x] Switching between two elimination round tabs shows different bracket results
- [x] Single-elimination and legacy (round_id = null) tournaments still render correctly

https://claude.ai/code/session_014chwvR2QVuDkzVWuA8uEFy