### PR TITLE
Add GitHub workflow to automatically delete Neon branches

### DIFF
--- a/.github/workflows/delete-neon-branch.yml
+++ b/.github/workflows/delete-neon-branch.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   delete-neon-branch:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch: ${{ github.head_ref }}
+          branch: ${{ github.event.pull_request.head.ref }}
           api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/delete-neon-branch.yml
+++ b/.github/workflows/delete-neon-branch.yml
@@ -1,0 +1,16 @@
+name: Delete Neon Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-neon-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Neon Branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: ${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically deletes Neon database branches when pull requests are closed.

## Changes
- Added `.github/workflows/delete-neon-branch.yml` workflow file that:
  - Triggers on pull request closed events
  - Uses the official Neon `delete-branch-action@v3` to clean up database branches
  - Passes the Neon project ID from repository variables
  - Uses the PR head ref to identify which branch to delete
  - Authenticates with Neon API using a stored secret

## Implementation Details
The workflow integrates with Neon's branch management by automatically cleaning up ephemeral database branches created for pull requests, helping to maintain a clean project state and avoid unnecessary resource usage.

https://claude.ai/code/session_01G5Q98TG3KsaWTu1SXYHXjU