### PR TITLE
Fix Neon branch deletion: add preview/ prefix

### DIFF
--- a/.github/workflows/delete-neon-branch.yml
+++ b/.github/workflows/delete-neon-branch.yml
@@ -13,5 +13,5 @@ jobs:
         uses: neondatabase/delete-branch-action@v3
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch: ${{ github.event.pull_request.head.ref }}
+          branch: preview/${{ github.event.pull_request.head.ref }}
           api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary

- Fixes the Neon branch deletion workflow introduced in #208
- The Vercel-Neon integration names branches as `preview/{git-branch}`, not the bare git branch name
- Updates `branch:` from `${{ github.event.pull_request.head.ref }}` to `preview/${{ github.event.pull_request.head.ref }}`

## Root cause

After #208 merged, the first workflow run failed with:
```
ERROR: Branch renovate/node-24.x not found.
Available branches: main, preview/renovate/node-24.x, ...
```

The Vercel-Neon integration consistently prefixes all preview branches with `preview/`.

https://claude.ai/code/session_01G5Q98TG3KsaWTu1SXYHXjU

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5Q98TG3KsaWTu1SXYHXjU)_