### PR TITLE
Separate pool leaderboards and seed elimination from pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1859,9 +1859,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1877,9 +1874,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1897,9 +1891,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1915,9 +1906,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2424,9 +2412,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2444,9 +2429,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2464,9 +2446,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2484,9 +2463,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,9 +2480,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2524,9 +2497,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3001,9 +2971,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3021,9 +2988,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3041,9 +3005,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3061,9 +3022,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7773,6 +7731,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/src/app/api/tournament/[tournamentId]/seed-from-pools/[poolsRoundId]/route.ts
+++ b/src/app/api/tournament/[tournamentId]/seed-from-pools/[poolsRoundId]/route.ts
@@ -1,0 +1,133 @@
+"use server";
+
+import { getTournamentPlayers } from "@/database/getTournamentPlayers";
+import { updatePlayersBracketSeeding } from "@/database/newPlayer";
+import { getSession } from "@/helpers/getsession";
+import winPercentage from "@/helpers/winPercentage";
+import { Player } from "@/types/Player";
+
+type Params = {
+  params: Promise<{
+    tournamentId: string;
+    poolsRoundId: string;
+  }>;
+};
+
+function seeding(players: Player[]) {
+  const participantsCount = players.length;
+  const rounds = Math.ceil(Math.log(participantsCount) / Math.log(2));
+  const bracketSize = Math.pow(2, rounds);
+
+  if (participantsCount < 2) {
+    return [];
+  }
+
+  let matches = [[1, 2]];
+
+  for (let round = 1; round < rounds; round++) {
+    const roundMatches: number[][] = [];
+    const sum = Math.pow(2, round + 1) + 1;
+
+    for (let i = 0; i < matches.length; i++) {
+      const home = changeIntoBye(matches[i][0], participantsCount);
+      const away = changeIntoBye(sum - matches[i][0], participantsCount);
+      roundMatches.push([home, away]);
+
+      const home2 = changeIntoBye(sum - matches[i][1], participantsCount);
+      const away2 = changeIntoBye(matches[i][1], participantsCount);
+      roundMatches.push([home2, away2]);
+    }
+    matches = roundMatches;
+  }
+
+  // suppress unused variable warning from bracketSize
+  void bracketSize;
+
+  return matches;
+}
+
+function changeIntoBye(seed: number, playerCount: number) {
+  return seed <= playerCount ? seed : -1;
+}
+
+export async function GET(request: Request, { params }: Params) {
+  const { tournamentId, poolsRoundId } = await params;
+
+  const token = await getSession();
+  if (!token.success || token.value.role !== "admin") {
+    return new Response("Unauthorized access", { status: 403 });
+  }
+
+  const tid = Number(tournamentId);
+  const rid = Number(poolsRoundId);
+
+  if (!Number.isSafeInteger(tid) || !Number.isSafeInteger(rid)) {
+    return new Response("Invalid parameters", { status: 400 });
+  }
+
+  const status = await getTournamentPlayers(tid);
+  if (!status.success) {
+    return new Response(status.error, { status: 400 });
+  }
+
+  // Filter each player's matches to only those from the pools round
+  const playersWithPoolMatches: Player[] = status.value.map((p) => ({
+    ...p,
+    matches: p.matches.filter((m) => m.round_id === rid),
+  }));
+
+  // Sort by win percentage in the pools round (descending)
+  playersWithPoolMatches.sort((a, b) => {
+    const aRate = winPercentage(a);
+    const bRate = winPercentage(b);
+    if (aRate !== bRate) return bRate - aRate;
+    return 0;
+  });
+
+  const seedPairs = seeding(playersWithPoolMatches);
+  if (seedPairs.length === 0) {
+    return new Response("Not enough players to seed", { status: 400 });
+  }
+
+  // Assign bracket_match and bracket_seed to each player in-memory
+  const seededPlayers: Player[] = seedPairs
+    .flatMap((seeds, i) => {
+      const p1 = playersWithPoolMatches[seeds[0] - 1] ?? null;
+      const p2 = playersWithPoolMatches[seeds[1] - 1] ?? null;
+
+      if (p1) {
+        p1.player.bracket_match = i + 1;
+        p1.player.bracket_seed = seeds[0];
+      }
+      if (p2) {
+        p2.player.bracket_match = i + 1;
+        p2.player.bracket_seed = seeds[1];
+      }
+
+      return [p1, p2];
+    })
+    .filter((p): p is Player => p !== null);
+
+  const updated = await updatePlayersBracketSeeding(seededPlayers);
+  if (!updated.success) {
+    return new Response(updated.error, { status: 400 });
+  }
+
+  // Build a map of updated bracket data to apply to the full player list
+  const bracketMap = new Map(
+    seededPlayers.map((p) => [
+      p.player.player_name,
+      { bracket_match: p.player.bracket_match, bracket_seed: p.player.bracket_seed },
+    ]),
+  );
+
+  const result = status.value.map((p) => {
+    const bracket = bracketMap.get(p.player.player_name);
+    if (bracket) {
+      return { ...p, player: { ...p.player, ...bracket } };
+    }
+    return p;
+  });
+
+  return new Response(JSON.stringify(result), { status: 200 });
+}

--- a/src/app/api/tournament/[tournamentId]/seed-from-pools/[poolsRoundId]/route.ts
+++ b/src/app/api/tournament/[tournamentId]/seed-from-pools/[poolsRoundId]/route.ts
@@ -2,8 +2,10 @@
 
 import { getTournamentPlayers } from "@/database/getTournamentPlayers";
 import { updatePlayersBracketSeeding } from "@/database/newPlayer";
+import { getRounds } from "@/database/getRounds";
 import { getSession } from "@/helpers/getsession";
 import winPercentage from "@/helpers/winPercentage";
+import { hitIndex } from "@/helpers/hitIndex";
 import { Player } from "@/types/Player";
 
 type Params = {
@@ -16,7 +18,6 @@ type Params = {
 function seeding(players: Player[]) {
   const participantsCount = players.length;
   const rounds = Math.ceil(Math.log(participantsCount) / Math.log(2));
-  const bracketSize = Math.pow(2, rounds);
 
   if (participantsCount < 2) {
     return [];
@@ -29,19 +30,17 @@ function seeding(players: Player[]) {
     const sum = Math.pow(2, round + 1) + 1;
 
     for (let i = 0; i < matches.length; i++) {
-      const home = changeIntoBye(matches[i][0], participantsCount);
-      const away = changeIntoBye(sum - matches[i][0], participantsCount);
-      roundMatches.push([home, away]);
-
-      const home2 = changeIntoBye(sum - matches[i][1], participantsCount);
-      const away2 = changeIntoBye(matches[i][1], participantsCount);
-      roundMatches.push([home2, away2]);
+      roundMatches.push([
+        changeIntoBye(matches[i][0], participantsCount),
+        changeIntoBye(sum - matches[i][0], participantsCount),
+      ]);
+      roundMatches.push([
+        changeIntoBye(sum - matches[i][1], participantsCount),
+        changeIntoBye(matches[i][1], participantsCount),
+      ]);
     }
     matches = roundMatches;
   }
-
-  // suppress unused variable warning from bracketSize
-  void bracketSize;
 
   return matches;
 }
@@ -50,7 +49,7 @@ function changeIntoBye(seed: number, playerCount: number) {
   return seed <= playerCount ? seed : -1;
 }
 
-export async function GET(request: Request, { params }: Params) {
+export async function POST(request: Request, { params }: Params) {
   const { tournamentId, poolsRoundId } = await params;
 
   const token = await getSession();
@@ -65,6 +64,16 @@ export async function GET(request: Request, { params }: Params) {
     return new Response("Invalid parameters", { status: 400 });
   }
 
+  // Verify the round belongs to this tournament and is actually a pools round
+  const roundsResult = await getRounds(tid);
+  if (!roundsResult.success) {
+    return new Response("Could not fetch rounds", { status: 400 });
+  }
+  const targetRound = roundsResult.value.find((r) => r.id === rid);
+  if (!targetRound || targetRound.type !== "pools") {
+    return new Response("Round not found or not a pools round", { status: 400 });
+  }
+
   const status = await getTournamentPlayers(tid);
   if (!status.success) {
     return new Response(status.error, { status: 400 });
@@ -76,12 +85,12 @@ export async function GET(request: Request, { params }: Params) {
     matches: p.matches.filter((m) => m.round_id === rid),
   }));
 
-  // Sort by win percentage in the pools round (descending)
+  // Sort by win percentage, with hit index as tiebreaker (matches leaderboard logic)
   playersWithPoolMatches.sort((a, b) => {
     const aRate = winPercentage(a);
     const bRate = winPercentage(b);
     if (aRate !== bRate) return bRate - aRate;
-    return 0;
+    return hitIndex(b) - hitIndex(a);
   });
 
   const seedPairs = seeding(playersWithPoolMatches);
@@ -113,7 +122,7 @@ export async function GET(request: Request, { params }: Params) {
     return new Response(updated.error, { status: 400 });
   }
 
-  // Build a map of updated bracket data to apply to the full player list
+  // Apply updated bracket data to the full player list and return
   const bracketMap = new Map(
     seededPlayers.map((p) => [
       p.player.player_name,

--- a/src/components/Leaderboards/Leaderboard.tsx
+++ b/src/components/Leaderboards/Leaderboard.tsx
@@ -139,6 +139,7 @@ function LeaderboardTable({ players, heading }: LeaderboardTableProps) {
 }
 
 const Leaderboard = () => {
+  const t = useTranslations("Pool");
   const context = useTournamentContext();
 
   const allPlayers = useMemo(
@@ -148,6 +149,11 @@ const Leaderboard = () => {
   );
 
   const multiplePools = context.pools.length > 1;
+
+  const unassignedPlayers = useMemo(
+    () => (multiplePools ? allPlayers.filter((p) => p.player.pool_id === null) : []),
+    [allPlayers, multiplePools],
+  );
 
   if (context.loading) return null;
 
@@ -169,6 +175,9 @@ const Leaderboard = () => {
             />
           );
         })}
+        {unassignedPlayers.length > 0 && (
+          <LeaderboardTable players={unassignedPlayers} heading={t("unassigned")} />
+        )}
       </div>
     );
   }

--- a/src/components/Leaderboards/Leaderboard.tsx
+++ b/src/components/Leaderboards/Leaderboard.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { LeaderboardPlayer } from "@/components/Leaderboards/LeaderboardPlayer";
 import { useMemo, useState } from "react";
 import { Player } from "@/types/Player";
+import { PoolRow } from "@/database/getPools";
 import {
   LeaderboardBuilder,
   LeaderboardColumns,
@@ -33,22 +34,25 @@ function SortButton({ col, onSort, ariaLabel, tooltip, children }: SortButtonPro
   );
 }
 
-const Leaderboard = () => {
+interface LeaderboardTableProps {
+  players: Player[];
+  heading?: string;
+}
+
+function LeaderboardTable({ players, heading }: LeaderboardTableProps) {
   const t = useTranslations("Leaderboard");
-  const context = useTournamentContext();
   const [sortCol, setSortCol] = useState<LeaderboardColumns>("percentage");
   const [direction, setDirection] = useState<SortDirection>("DEFAULT");
 
-  const players = useMemo(() => {
-    const filteredPlayers: Player[] = context.players.filter(
-      (player) => player !== null,
-    ) as NonNullable<Player>[];
-    return new LeaderboardBuilder()
-      .players(filteredPlayers)
-      .direction(direction)
-      .column(sortCol)
-      .sort();
-  }, [context.players, direction, sortCol]);
+  const sorted = useMemo(
+    () =>
+      new LeaderboardBuilder()
+        .players(players)
+        .direction(direction)
+        .column(sortCol)
+        .sort(),
+    [players, direction, sortCol],
+  );
 
   function sortHandler(col: LeaderboardColumns) {
     if (sortCol === col && direction !== "DEFAULT") {
@@ -59,33 +63,28 @@ const Leaderboard = () => {
       setSortCol("percentage");
       return;
     }
-
     setDirection("ASC");
     setSortCol(col);
   }
 
   function sortIndicator(col: LeaderboardColumns) {
     if (sortCol !== col) return;
-
     if (direction === "ASC") return <span>↑</span>;
     if (direction === "DESC") return <span>↓</span>;
   }
 
-  function getAriaLabel(sortCol: LeaderboardColumns, col: LeaderboardColumns, label: string) {
-    if (sortCol === col && direction !== "DEFAULT") {
+  function getAriaLabel(active: LeaderboardColumns, col: LeaderboardColumns, label: string) {
+    if (active === col && direction !== "DEFAULT") {
       return `${label}, ${direction === "ASC" ? t("sortAscending") : t("sortDescending")}`;
     }
     return label;
   }
 
   return (
-    <div className="w-full md:w-2/3">
-      <div className="my-2 text-4xl font-bold flex justify-between">
-        <span className={context.loading ? "invisible" : ""}>
-          {context.loading ? "Lorem ipsum" : context.tournament?.name}
-        </span>
-      </div>
-
+    <div className="mb-6">
+      {heading && (
+        <h3 className="text-xl font-semibold mb-2 text-slate-700">{heading}</h3>
+      )}
       <div className="overflow-auto border-2 border-slate-500 rounded-md shadow-md">
         <table className="w-full border-collapse border">
           <thead>
@@ -123,20 +122,65 @@ const Leaderboard = () => {
               </th>
             </tr>
           </thead>
-          {!context.loading ? (
-            <tbody>
-              {players.map((player, i) => (
-                <LeaderboardPlayer
-                  key={player.player.player_name}
-                  player={player}
-                  nthRow={i}
-                />
-              ))}
-            </tbody>
-          ) : null}
+          <tbody>
+            {sorted.map((player, i) => (
+              <LeaderboardPlayer
+                key={player.player.player_name}
+                player={player}
+                nthRow={i}
+              />
+            ))}
+          </tbody>
         </table>
         <Loading />
       </div>
+    </div>
+  );
+}
+
+const Leaderboard = () => {
+  const context = useTournamentContext();
+
+  const allPlayers = useMemo(
+    () =>
+      context.players.filter((player) => player !== null) as NonNullable<Player>[],
+    [context.players],
+  );
+
+  const multiplePools = context.pools.length > 1;
+
+  if (context.loading) return null;
+
+  if (multiplePools) {
+    return (
+      <div className="w-full md:w-2/3">
+        <div className="my-2 text-4xl font-bold">
+          <span>{context.tournament?.name}</span>
+        </div>
+        {context.pools.map((pool: PoolRow) => {
+          const poolPlayers = allPlayers.filter(
+            (p) => p.player.pool_id === pool.id,
+          );
+          return (
+            <LeaderboardTable
+              key={pool.id}
+              players={poolPlayers}
+              heading={pool.name}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full md:w-2/3">
+      <div className="my-2 text-4xl font-bold flex justify-between">
+        <span className={context.loading ? "invisible" : ""}>
+          {context.loading ? "Lorem ipsum" : context.tournament?.name}
+        </span>
+      </div>
+      <LeaderboardTable players={allPlayers} />
     </div>
   );
 };

--- a/src/components/Leaderboards/LeaderboardSidebar.tsx
+++ b/src/components/Leaderboards/LeaderboardSidebar.tsx
@@ -3,26 +3,96 @@
 import { useTournamentContext } from "@/context/TournamentContext";
 import { LeaderboardBuilder } from "@/helpers/leaderboardSort";
 import { Player } from "@/types/Player";
+import { PoolRow } from "@/database/getPools";
 import { TrophyIcon } from "@heroicons/react/24/solid";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
+
+interface PlayerRowProps {
+  player: Player;
+  index: number;
+}
+
+function PlayerRow({ player, index }: PlayerRowProps) {
+  return (
+    <tr className="*:text-center *:py-4 odd:bg-white even:bg-gray-100">
+      <td className="relative">
+        <p>{index + 1}.</p>
+        {index < 3 && (
+          <div className="absolute inset-y-0 left-6 flex items-center justify-center w-full">
+            <TrophyIcon
+              className={`w-6 h-6 ${
+                index === 0
+                  ? "text-yellow-400"
+                  : index === 1
+                    ? "text-gray-700"
+                    : "text-amber-950"
+              }`}
+            />
+          </div>
+        )}
+      </td>
+      <td>{player.player.player_name}</td>
+    </tr>
+  );
+}
+
+interface PoolSectionProps {
+  pool: PoolRow;
+  players: Player[];
+  activeRoundId: number | null;
+}
+
+function PoolSection({ pool, players, activeRoundId }: PoolSectionProps) {
+  const sorted = new LeaderboardBuilder()
+    .players(players)
+    .round(activeRoundId)
+    .ascending()
+    .column("percentage")
+    .sort();
+
+  return (
+    <>
+      <tr className="bg-gray-200">
+        <td colSpan={2} className="py-2 px-4 font-semibold text-slate-700 text-sm">
+          {pool.name}
+        </td>
+      </tr>
+      {sorted.map((player, index) => (
+        <PlayerRow key={player.player.player_name} player={player} index={index} />
+      ))}
+    </>
+  );
+}
 
 const LeaderboardSidebar = () => {
   const t = useTranslations("Leaderboard");
   const context = useTournamentContext();
 
-  const players = useMemo(() => {
-    const filteredPlayers: Player[] = context.players.filter((player) => player !== null) as NonNullable<Player>[];
-    const activeRoundId =
+  const activeRoundId = useMemo(
+    () =>
       context.rounds.find((r) => r.round_order === context.activeRound)?.id ??
-      null;
+      null,
+    [context.rounds, context.activeRound],
+  );
+
+  const allPlayers = useMemo(
+    () =>
+      context.players.filter((player) => player !== null) as NonNullable<Player>[],
+    [context.players],
+  );
+
+  const multiplePools = context.pools.length > 1;
+
+  const sortedPlayers = useMemo(() => {
+    if (multiplePools) return [];
     return new LeaderboardBuilder()
-      .players(filteredPlayers)
+      .players(allPlayers)
       .round(activeRoundId)
       .ascending()
       .column("percentage")
       .sort();
-  }, [context.activeRound, context.players, context.rounds]);
+  }, [allPlayers, activeRoundId, multiplePools]);
 
   return (
     <div className="lg:max-w-sm lg:w-1/5 border-2 rounded-md shadow-md border-gray-400">
@@ -34,30 +104,22 @@ const LeaderboardSidebar = () => {
           </tr>
         </thead>
         <tbody>
-          {players.map((player, index) => (
-            <tr
-              key={index}
-              className="*:text-center *:py-4 odd:bg-white even:bg-gray-100"
-            >
-              <td className="relative">
-                <p>{index + 1}.</p>
-                {/* trophy icons to top 3 */}
-                {index < 3 && (
-                  <div className="absolute inset-y-0 left-6 flex items-center justify-center w-full">
-                    <TrophyIcon
-                      className={`w-6 h-6 ${index === 0
-                        ? "text-yellow-400"
-                        : index === 1
-                          ? "text-gray-700"
-                          : "text-amber-950"
-                        }`}
-                    />
-                  </div>
-                )}
-              </td>
-              <td>{player.player.player_name}</td>
-            </tr>
-          ))}
+          {multiplePools
+            ? context.pools.map((pool) => (
+                <PoolSection
+                  key={pool.id}
+                  pool={pool}
+                  players={allPlayers.filter((p) => p.player.pool_id === pool.id)}
+                  activeRoundId={activeRoundId}
+                />
+              ))
+            : sortedPlayers.map((player, index) => (
+                <PlayerRow
+                  key={player.player.player_name}
+                  player={player}
+                  index={index}
+                />
+              ))}
         </tbody>
       </table>
     </div>

--- a/src/components/Leaderboards/LeaderboardSidebar.tsx
+++ b/src/components/Leaderboards/LeaderboardSidebar.tsx
@@ -67,6 +67,7 @@ function PoolSection({ pool, players, activeRoundId }: PoolSectionProps) {
 
 const LeaderboardSidebar = () => {
   const t = useTranslations("Leaderboard");
+  const tPool = useTranslations("Pool");
   const context = useTournamentContext();
 
   const activeRoundId = useMemo(
@@ -83,6 +84,11 @@ const LeaderboardSidebar = () => {
   );
 
   const multiplePools = context.pools.length > 1;
+
+  const unassignedPlayers = useMemo(
+    () => (multiplePools ? allPlayers.filter((p) => p.player.pool_id === null) : []),
+    [allPlayers, multiplePools],
+  );
 
   const sortedPlayers = useMemo(() => {
     if (multiplePools) return [];
@@ -105,14 +111,25 @@ const LeaderboardSidebar = () => {
         </thead>
         <tbody>
           {multiplePools
-            ? context.pools.map((pool) => (
-                <PoolSection
-                  key={pool.id}
-                  pool={pool}
-                  players={allPlayers.filter((p) => p.player.pool_id === pool.id)}
-                  activeRoundId={activeRoundId}
-                />
-              ))
+            ? (
+              <>
+                {context.pools.map((pool) => (
+                  <PoolSection
+                    key={pool.id}
+                    pool={pool}
+                    players={allPlayers.filter((p) => p.player.pool_id === pool.id)}
+                    activeRoundId={activeRoundId}
+                  />
+                ))}
+                {unassignedPlayers.length > 0 && (
+                  <PoolSection
+                    pool={{ id: -1, tournament_id: -1, name: tPool("unassigned") }}
+                    players={unassignedPlayers}
+                    activeRoundId={activeRoundId}
+                  />
+                )}
+              </>
+            )
             : sortedPlayers.map((player, index) => (
                 <PlayerRow
                   key={player.player.player_name}

--- a/src/components/Results/Brackets/Tournament.test.tsx
+++ b/src/components/Results/Brackets/Tournament.test.tsx
@@ -12,8 +12,9 @@ vi.mock("@/database/getTournament", () => ({
     .mockResolvedValue({ success: true, value: [] }),
 }));
 
+const mockUseUserContext = vi.fn(() => ({ user: null, setUser: vi.fn() }));
 vi.mock("@/context/UserContext", () => ({
-  useUserContext: () => ({ user: null, setUser: vi.fn() }),
+  useUserContext: () => mockUseUserContext(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -55,6 +56,7 @@ const messages = {
   Brackets: {
     selectseed: "Select a tournament to seed from",
     noRRtournamentsfound: "No tournaments found",
+    seedFromPools: "Seed bracket from pools round",
   },
   NewMatch: {
     match: "Match",
@@ -274,5 +276,114 @@ describe("Brackets/Tournament — multi-elimination round switching", () => {
     // No player cells should appear
     expect(screen.queryByText("Alice")).toBeNull();
     expect(screen.queryByText("Bob")).toBeNull();
+  });
+});
+
+// ── Seed-from-pools tests ───────────────────────────────────────────────────
+
+const adminUser = { user: { role: "admin", username: "admin" }, setUser: vi.fn() };
+
+const poolsRound = { id: 5, tournament_id: 1, round_order: 1, type: "pools" };
+const elimRound = { id: 6, tournament_id: 1, round_order: 2, type: "elimination" };
+
+const poolMatch = {
+  ...{ tournament_id: 1, submitted_by_token: null, submitted_at: null },
+  id: 99,
+  player1: "Alice",
+  player2: "Bob",
+  player1_hits: 5,
+  player2_hits: 2,
+  winner: "Alice",
+  match: 1,
+  round_id: 5,
+};
+
+const aliceWithPoolMatch: Player = {
+  player: { player_name: "Alice", tournament_id: 1, bracket_match: null, bracket_seed: null, pool_id: null },
+  matches: [poolMatch],
+};
+const bobWithPoolMatch: Player = {
+  player: { player_name: "Bob", tournament_id: 1, bracket_match: null, bracket_seed: null, pool_id: null },
+  matches: [poolMatch],
+};
+
+describe("Brackets/Tournament — seed from pools round", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseUserContext.mockReturnValue({ user: null, setUser: vi.fn() });
+  });
+
+  it("shows 'seed from pools' button when admin views unseeded elimination round that follows a pools round", () => {
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2,
+      rounds: [poolsRound, elimRound],
+      players: [aliceWithPoolMatch, bobWithPoolMatch],
+    });
+    mockUseUserContext.mockReturnValue(adminUser);
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    expect(screen.getByText("Seed bracket from pools round")).toBeTruthy();
+  });
+
+  it("does not show 'seed from pools' button when players are already seeded", () => {
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2,
+      rounds: [poolsRound, elimRound],
+      players: [
+        { ...aliceWithPoolMatch, player: { ...aliceWithPoolMatch.player, bracket_seed: 1 } },
+        { ...bobWithPoolMatch, player: { ...bobWithPoolMatch.player, bracket_seed: 2 } },
+      ],
+    });
+    mockUseUserContext.mockReturnValue(adminUser);
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    expect(screen.queryByText("Seed bracket from pools round")).toBeNull();
+  });
+
+  it("does not show 'seed from pools' button for non-admin users", () => {
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2,
+      rounds: [poolsRound, elimRound],
+      players: [aliceWithPoolMatch, bobWithPoolMatch],
+    });
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    expect(screen.queryByText("Seed bracket from pools round")).toBeNull();
+  });
+
+  it("does not show 'seed from pools' button when the active round has no preceding pools round", () => {
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2,
+      rounds: twoEliminationRounds,
+      players: [alice, bob],
+    });
+    mockUseUserContext.mockReturnValue(adminUser);
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    expect(screen.queryByText("Seed bracket from pools round")).toBeNull();
   });
 });

--- a/src/components/Results/Brackets/Tournament.test.tsx
+++ b/src/components/Results/Brackets/Tournament.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, waitFor } from "@testing-library/react";
 import { render, screen } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import Tournament from "./Tournament";
@@ -386,4 +387,49 @@ describe("Brackets/Tournament — seed from pools round", () => {
 
     expect(screen.queryByText("Seed bracket from pools round")).toBeNull();
   });
+
+  it("calls the seed-from-pools endpoint and updates context players when button is clicked", async () => {
+    const setPlayers = vi.fn();
+    const setLoading = vi.fn();
+    mockUseTournamentContext.mockReturnValue({
+      ...baseTournamentContext,
+      activeRound: 2,
+      rounds: [poolsRound, elimRound],
+      players: [aliceWithPoolMatch, bobWithPoolMatch],
+      setPlayers,
+      setLoading,
+    });
+    mockUseUserContext.mockReturnValue(adminUser);
+
+    const seededPlayers = [
+      { ...aliceWithPoolMatch, player: { ...aliceWithPoolMatch.player, bracket_seed: 1, bracket_match: 1 } },
+      { ...bobWithPoolMatch, player: { ...bobWithPoolMatch.player, bracket_seed: 2, bracket_match: 1 } },
+    ];
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify(seededPlayers)),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Tournament />
+      </NextIntlClientProvider>,
+    );
+
+    fireEvent.click(screen.getByText("Seed bracket from pools round"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/tournament/1/seed-from-pools/${poolsRound.id}`,
+        { method: "POST" },
+      );
+      expect(setPlayers).toHaveBeenCalledWith(seededPlayers);
+    });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });

--- a/src/components/Results/Brackets/Tournament.tsx
+++ b/src/components/Results/Brackets/Tournament.tsx
@@ -255,6 +255,7 @@ export default function Tournament() {
     try {
       const res = await fetch(
         `/api/tournament/${context.tournament.id}/seed-from-pools/${poolsRoundId}`,
+        { method: "POST" },
       );
 
       if (!res.ok) {

--- a/src/components/Results/Brackets/Tournament.tsx
+++ b/src/components/Results/Brackets/Tournament.tsx
@@ -247,6 +247,35 @@ export default function Tournament() {
     [buildRound],
   );
 
+  // Seed this elimination round from the results of a preceding pools round
+  async function seedFromPools(poolsRoundId: number) {
+    if (context.loading || !context.tournament) return;
+
+    context.setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/tournament/${context.tournament.id}/seed-from-pools/${poolsRoundId}`,
+      );
+
+      if (!res.ok) {
+        context.setLoading(false);
+        return;
+      }
+
+      const players = jsonParser<Player[]>(await res.text());
+      if (!players.success) {
+        context.setLoading(false);
+        return;
+      }
+
+      context.setPlayers(players.value);
+    } catch (error) {
+      console.error(error);
+    }
+
+    context.setLoading(false);
+  }
+
   // Seed this tournament based on another tournament
   async function seedTournament(tournamentId: number) {
     if (context.loading) return;
@@ -396,6 +425,16 @@ export default function Tournament() {
     return;
   }
 
+  const activeRoundData = context.rounds.find(
+    (r) => r.round_order === context.activeRound,
+  );
+  const precedingPoolsRound = activeRoundData?.type === "elimination"
+    ? context.rounds
+        .filter((r) => r.type === "pools" && r.round_order < activeRoundData.round_order)
+        .sort((a, b) => b.round_order - a.round_order)[0]
+    : undefined;
+  const alreadySeeded = context.players.some((p) => p?.player.bracket_seed);
+
   return (
     <>
       <div className="container mx-auto sm:my-2 items-center text-xl sm:text-4xl font-bold flex justify-between gap-4">
@@ -428,6 +467,19 @@ export default function Tournament() {
           ) : (
             <p>{t("noRRtournamentsfound")}</p>
           )}
+        </div>
+      ) : null}
+
+      {/* seed elimination bracket from preceding pools round */}
+      {precedingPoolsRound && !alreadySeeded && account.user?.role === "admin" ? (
+        <div className="container mx-auto w-full space-y-5">
+          <button
+            type="button"
+            className="py-4 px-6 rounded-md shadow-xs border border-black hover:bg-gray-100"
+            onClick={() => seedFromPools(precedingPoolsRound.id)}
+          >
+            {t("seedFromPools")}
+          </button>
         </div>
       ) : null}
 

--- a/src/database/newPlayer.test.ts
+++ b/src/database/newPlayer.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { updatePlayersBracketSeeding } from "./newPlayer";
+import { db } from "./database";
+import type { Player } from "@/types/Player";
+
+vi.mock("./database", () => ({
+  db: {
+    selectFrom: vi.fn(),
+    insertInto: vi.fn(),
+    updateTable: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+function makePlayer(name: string, bracketMatch: number, bracketSeed: number): Player {
+  return {
+    player: {
+      player_name: name,
+      tournament_id: 1,
+      bracket_match: bracketMatch,
+      bracket_seed: bracketSeed,
+      pool_id: null,
+    },
+    matches: [],
+  };
+}
+
+function makeTrxMock() {
+  const executeMock = vi.fn().mockResolvedValue(undefined);
+  const whereMock2 = vi.fn().mockReturnValue({ execute: executeMock });
+  const whereMock1 = vi.fn().mockReturnValue({ where: whereMock2 });
+  const setMock = vi.fn().mockReturnValue({ where: whereMock1 });
+  const updateTableMock = vi.fn().mockReturnValue({ set: setMock });
+  return { updateTable: updateTableMock, execute: executeMock };
+}
+
+describe("updatePlayersBracketSeeding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates bracket_match and bracket_seed for each player", async () => {
+    const trx = makeTrxMock();
+    (db.transaction as any).mockReturnValue({
+      execute: vi.fn().mockImplementation((cb: (t: typeof trx) => Promise<void>) => cb(trx)),
+    });
+
+    const players = [makePlayer("Alice", 1, 1), makePlayer("Bob", 1, 2)];
+    const result = await updatePlayersBracketSeeding(players);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.value).toBe(2);
+    expect(trx.updateTable).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns success with 0 when player list is empty", async () => {
+    const result = await updatePlayersBracketSeeding([]);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.value).toBe(0);
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it("skips players with null bracket_match", async () => {
+    const trx = makeTrxMock();
+    (db.transaction as any).mockReturnValue({
+      execute: vi.fn().mockImplementation((cb: (t: typeof trx) => Promise<void>) => cb(trx)),
+    });
+
+    const players = [
+      makePlayer("Alice", 1, 1),
+      { ...makePlayer("Bob", 1, 2), player: { ...makePlayer("Bob", 1, 2).player, bracket_match: null } },
+    ];
+    const result = await updatePlayersBracketSeeding(players);
+
+    expect(result.success).toBe(true);
+    expect(trx.updateTable).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns failure when the transaction throws", async () => {
+    (db.transaction as any).mockReturnValue({
+      execute: vi.fn().mockRejectedValue(new Error("DB error")),
+    });
+
+    const players = [makePlayer("Alice", 1, 1)];
+    const result = await updatePlayersBracketSeeding(players);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toBeTruthy();
+  });
+});

--- a/src/database/newPlayer.ts
+++ b/src/database/newPlayer.ts
@@ -95,6 +95,32 @@ export async function addPlayer(
   }
 }
 
+export async function updatePlayersBracketSeeding(
+  players: Player[],
+): Promise<Result<number, string>> {
+  const toUpdate = players.filter((p) => p && p.player.bracket_match !== null);
+  if (!toUpdate.length) return { success: true, value: 0 };
+
+  try {
+    await db.transaction().execute(async (trx) => {
+      for (const player of toUpdate) {
+        await trx
+          .updateTable("tournament_players")
+          .set({
+            bracket_match: player.player.bracket_match,
+            bracket_seed: player.player.bracket_seed,
+          })
+          .where("player_name", "=", player.player.player_name)
+          .where("tournament_id", "=", player.player.tournament_id)
+          .execute();
+      }
+    });
+    return { success: true, value: toUpdate.length };
+  } catch {
+    return { success: false, error: "Error updating player bracket seeding" };
+  }
+}
+
 export async function addPlayers(
   players: Player[],
 ): Promise<Result<number, string>> {

--- a/src/languages/ee.json
+++ b/src/languages/ee.json
@@ -176,7 +176,8 @@
   },
   "Brackets": {
     "selectseed": "Valige turniirilt mängu järjekord",
-    "noRRtournamentsfound": "Turniire ei leitud"
+    "noRRtournamentsfound": "Turniire ei leitud",
+    "seedFromPools": "Seedi brakett poolivoorust"
   },
   "BulkEntry": {
     "title": "DT Tulemuste Sisestus",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -176,7 +176,8 @@
   },
   "Brackets": {
     "selectseed": "Select match order from tournament",
-    "noRRtournamentsfound": "No tournaments found"
+    "noRRtournamentsfound": "No tournaments found",
+    "seedFromPools": "Seed bracket from pools round"
   },
   "BulkEntry": {
     "title": "DT Results Entry",

--- a/src/languages/fi.json
+++ b/src/languages/fi.json
@@ -176,7 +176,8 @@
   },
   "Brackets": {
     "selectseed": "Valitse ottelujärjestys turnauksesta",
-    "noRRtournamentsfound": "Ei turnauksia löydetty"
+    "noRRtournamentsfound": "Ei turnauksia löydetty",
+    "seedFromPools": "Laske sijoitukset poolikierroksesta"
   },
   "BulkEntry": {
     "title": "DT Tulosten Syöttö",

--- a/src/languages/se.json
+++ b/src/languages/se.json
@@ -176,7 +176,8 @@
   },
   "Brackets": {
     "selectseed": "Välj matchordning från turneringen",
-    "noRRtournamentsfound": "Inga turneringar hittades"
+    "noRRtournamentsfound": "Inga turneringar hittades",
+    "seedFromPools": "Placera bracket från poolrunda"
   },
   "BulkEntry": {
     "title": "DT Resultatinmatning",


### PR DESCRIPTION
- LeaderboardSidebar: when 2+ pools exist, show a ranked section per pool
  instead of one combined ranking
- Leaderboard (full view): same separation into per-pool tables, each with
  independent sort controls
- Brackets/Tournament: add "Seed bracket from pools round" button that appears
  for admins on an unseeded elimination round that follows a pools round;
  calls new endpoint to rank players by pool-round win % and assign
  bracket_match / bracket_seed
- New API route GET /api/tournament/[id]/seed-from-pools/[poolsRoundId]:
  reads pool-round matches, sorts players, applies seeding algorithm, and
  updates existing tournament_players rows (no insert)
- updatePlayersBracketSeeding(): new DB helper that updates bracket_match and
  bracket_seed on existing tournament_players rows via a transaction
- Translation key Brackets.seedFromPools added to all four language files
- Tests: updated Brackets/Tournament.test.tsx with 4 new cases covering the
  seed-from-pools button visibility rules

https://claude.ai/code/session_01KkJCU7kPAhEocDLVmSiqw5